### PR TITLE
Improve Cargo.toml usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ by request path.
 To use the library just add:
 
 ```
-hyper-router = "*"
+hyper = "0.11"
+hyper-router = "0.4"
 ```
 
 to your dependencies.


### PR DESCRIPTION
Specifying version number for hyper-router makes sure that no
non-backwards compatible changes get installed unexpectedly,
while allowing updates like 0.4.1, 0.4.2, etc...

Hyper needs to be specified or a "can't find crate" error occurs.