### PR TITLE
Hyper 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,13 +7,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.6.0"
+name = "arrayvec"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
@@ -22,11 +26,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.4.4"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -35,17 +39,92 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "futures"
-version = "0.1.14"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures-cpupool"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "h2"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "http"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -55,41 +134,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hyper-router"
 version = "0.4.0"
 dependencies = [
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "iovec"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -103,59 +190,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "lazy_static"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lazy_static"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "lazycell"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.28"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.3.8"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "memchr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.2"
+name = "memoffset"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicase 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "mio"
-version = "0.6.9"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -165,42 +254,42 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "net2"
-version = "0.2.30"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "nodrop"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "rand"
-version = "0.3.15"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -226,40 +315,17 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rustc_version"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "safemem"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "scoped-tls"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "semver"
-version = "0.1.20"
+name = "scopeguard"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "slab"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "smallvec"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "take"
+name = "string"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -278,68 +344,132 @@ version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "tokio-core"
-version = "0.1.9"
+name = "tokio"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-fs 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-udp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-codec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-executor"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-fs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-reactor"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "tokio-proto"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-service"
+name = "tokio-tcp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "unicase"
-version = "2.0.0"
+name = "tokio-threadpool"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "tokio-timer"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-udp"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unreachable"
@@ -360,13 +490,42 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "want"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-build"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -380,49 +539,65 @@ dependencies = [
 
 [metadata]
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
-"checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
+"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
+"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
-"checksum bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8b24f16593f445422331a5eed46b72f7f171f910fead4f2ea8f17e727e9c5c14"
+"checksum bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dd32989a66957d3f0cba6588f15d4281a733f4e9ffc43fcd2385f57d3bf99ff"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4b63a4792d4f8f686defe3b39b92127fea6344de5d38202b2ee5a11bbbf29d6a"
-"checksum futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a283c84501e92cade5ea673a2a7ca44f71f209ccdd302a3e0896f50083d2c5ff"
+"checksum crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe8153ef04a7594ded05b427ffad46ddeaf22e63fd48d42b3e1e3bb4db07cae7"
+"checksum crossbeam-epoch 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2af0e75710d6181e234c8ecc79f14a97907850a541b13b0be1dd10992f2e4620"
+"checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
+"checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
+"checksum h2 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "6229ac66d3392dd83288fe04defd4b353354b15bbe07820d53dda063a736afcc"
+"checksum http 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6861b042450b6333fa7212b6edffc2d6df22579042817d59d49f4f8afbaaaf74"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
-"checksum hyper 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "75f57d451deabf8ad8fa1488d27b24834c9f5b6ca996da8d0c9dc5ce9c8d4d34"
-"checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
+"checksum hyper 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6416251e6672bff06fe96a3337570772845a44500fba2d178e2e55e0fab58a86"
+"checksum indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08173ba1e906efb6538785a8844dd496f5d34f0a2d88038e95195172fc667220"
+"checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
-"checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
-"checksum libc 0.2.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb7b49972ee23d8aa1026c365a5b440ba08e35075f18c459980c7395c221ec48"
-"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
+"checksum lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6412c5e2ad9584b0b8e979393122026cdd6d2a80b933f890dcd694ddbe73739"
+"checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
+"checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
+"checksum log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6fddaa003a65722a7fb9e26b0ce95921fe4ba590542ced664d8ce2fa26f9f3ac"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
-"checksum mime 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c5ca99d8a021c1687882fd68dca26e601ceff5c26571c7cb41cf4ed60d57cb2d"
-"checksum mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9e965267d4d58496fc4f740e9861118367f13570cadf66316ed2c3f2f14d87c7"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
+"checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum net2 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "94101fd932816f97eb9a5116f6c1a11511a1fed7db21c5ccd823b2dc11abf566"
+"checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
+"checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
-"checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
-"checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "80dcf663dc552529b9bfc7bdb30ea12e5fa5d3545137d850a91ad410053f68e9"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
-"checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-"checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
-"checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
-"checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
-"checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
-"checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
-"checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
+"checksum string 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "31f98b200e7caca9efca50fc0aa69cd58a5ec81d5f6e75b2f3ecaad2e998972a"
 "checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
-"checksum tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e85d419699ec4b71bfe35bbc25bb8771e52eff0471a7f75c853ad06e200b4f86"
-"checksum tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c2c3ce9739f7387a0fa65b5421e81feae92e04d603f008898f4257790ce8c2db"
-"checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
-"checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
-"checksum unicase 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e01da42520092d0cd2d6ac3ae69eb21a22ad43ff195676b86f8c37f487d6b80"
+"checksum tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ee337e5f4e501fc32966fec6fe0ca0cc1c237b0b1b14a335f8bfe3c5f06e286"
+"checksum tokio-codec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "881e9645b81c2ce95fcb799ded2c29ffb9f25ef5bef909089a420e5961dd8ccb"
+"checksum tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8cac2a7883ff3567e9d66bb09100d09b33d90311feca0206c7ca034bc0c55113"
+"checksum tokio-fs 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fc42bae2f6e33865b99069d95bcddfc85c9f0849b4e7e7399eeee71956ef34d7"
+"checksum tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a5c9635ee806f26d302b8baa1e145689a280d8f5aa8d0552e7344808da54cc21"
+"checksum tokio-reactor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e00ec63bbec2c97ce1178cb0587b2c438b2f6b09d3ee54a33c45a9cf0d530810"
+"checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
+"checksum tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c3873a6d8d0b636e024e77b9a82eaab6739578a06189ecd0e731c7308fbc5d"
+"checksum tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "028b94314065b90f026a21826cffd62a4e40a92cda3e5c069cc7b02e5945f5e9"
+"checksum tokio-udp 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43eb534af6e8f37d43ab1b612660df14755c42bd003c5f8d2475ee78cc4600c0"
+"checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a05d9d966753fa4b5c8db73fcab5eed4549cfe0e1e4e66911e5564a0085c35d1"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ path = "src/lib.rs"
 
 [dependencies]
 futures = "^0.1"
-hyper = "^0.11"
+hyper = "^0.12"
 regex = "^0.2"
+http = "^0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-router"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Marcin Radoszewski <moriturius@gmail.com>", "Alexander Mescheryakov <freecoder.xx@gmail.com>", "Mike Lubinets <lubinetsm@yandex.ru>"]
 description = "Simple routing middleware for Hyper http library."
 repository = "https://github.com/marad/hyper-router"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyper-router"
 version = "0.4.0"
-authors = ["Marcin Radoszewski <moriturius@gmail.com>", "Alexander Mescheryakov <freecoder.xx@gmail.com>"]
+authors = ["Marcin Radoszewski <moriturius@gmail.com>", "Alexander Mescheryakov <freecoder.xx@gmail.com>", "Mike Lubinets <lubinetsm@yandex.ru>"]
 description = "Simple routing middleware for Hyper http library."
 repository = "https://github.com/marad/hyper-router"
 keywords = ["hyper", "router", "routing", "middleware"]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,7 +2,7 @@ use super::Route;
 use super::Router;
 
 /// Builder for a router
-/// 
+///
 /// Example usage:
 ///
 #[derive(Debug)]
@@ -35,6 +35,8 @@ impl RouterBuilder {
     }
 
     pub fn build(self) -> Router {
-        Router { routes: self.routes }
+        Router {
+            routes: self.routes,
+        }
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -20,10 +20,10 @@ impl RouterBuilder {
     /// Example:
     ///
     /// ```ignore
-    /// use hyper::server::{Request, Response};
+    /// use hyper::{Body, Request, Response};
     /// use hyper_router::{Route, RouterBuilder};
     ///
-    /// fn some_handler(_: Request) -> Response {
+    /// fn some_handler(_: Request<Body>) -> Response<Body> {
     ///   // do something
     /// }
     ///

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,7 +1,5 @@
-use hyper::Body;
-use hyper::{Request, Response};
-use hyper::StatusCode;
 use hyper::header::CONTENT_TYPE;
+use hyper::{Body, Request, Response, StatusCode};
 
 pub fn default_404_handler(_: Request<Body>) -> Response<Body> {
     let body = "page not found";

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,8 +1,7 @@
 use hyper::Body;
 use hyper::{Request, Response};
 use hyper::StatusCode;
-use hyper::header::{CONTENT_LENGTH, CONTENT_TYPE};
-use http::Result;
+use hyper::header::CONTENT_TYPE;
 
 pub fn default_404_handler(_: Request<Body>) -> Response<Body> {
     let body = "page not found";

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,39 +1,41 @@
-use hyper::server::{Request, Response};
+use hyper::Body;
+use hyper::{Request, Response};
 use hyper::StatusCode;
-use hyper::header::{ContentLength, ContentType};
+use hyper::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use http::Result;
 
-pub fn default_404_handler(_: Request) -> Response {
+pub fn default_404_handler(_: Request<Body>) -> Response<Body> {
     let body = "page not found";
-    Response::new()
-        .with_status(StatusCode::NotFound)
-        .with_header(ContentLength(body.len() as u64))
-        .with_header(ContentType::plaintext())
-        .with_body(body)
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .header(CONTENT_TYPE, "text/plain")
+        .body(Body::from(body))
+        .expect("Failed to construct \"Not Found\" response")
 }
 
-pub fn method_not_supported_handler(_: Request) -> Response {
+pub fn method_not_supported_handler(_: Request<Body>) -> Response<Body> {
     let body = "method not supported";
-    Response::new()
-        .with_status(StatusCode::MethodNotAllowed)
-        .with_header(ContentLength(body.len() as u64))
-        .with_header(ContentType::plaintext())
-        .with_body(body)
+    Response::builder()
+        .status(StatusCode::METHOD_NOT_ALLOWED)
+        .header(CONTENT_TYPE, "text/plain")
+        .body(Body::from(body))
+        .expect("Failed to construct \"Method Not Supported\" response")
 }
 
-pub fn internal_server_error_handler(_: Request) -> Response {
+pub fn internal_server_error_handler(_: Request<Body>) -> Response<Body> {
     let body = "internal server error";
-    Response::new()
-        .with_status(StatusCode::InternalServerError)
-        .with_header(ContentLength(body.len() as u64))
-        .with_header(ContentType::plaintext())
-        .with_body(body)
+    Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .header(CONTENT_TYPE, "text/plain")
+        .body(Body::from(body))
+        .expect("Failed to construct \"Internal Server Error\" response")
 }
 
-pub fn not_implemented_handler(_: Request) -> Response {
+pub fn not_implemented_handler(_: Request<Body>) -> Response<Body> {
     let body = "not implemented";
-    Response::new()
-        .with_status(StatusCode::NotImplemented)
-        .with_header(ContentLength(body.len() as u64))
-        .with_header(ContentType::plaintext())
-        .with_body(body)
+    Response::builder()
+        .status(StatusCode::NOT_IMPLEMENTED)
+        .header(CONTENT_TYPE, "text/plain")
+        .body(Body::from(body))
+        .expect("Failed to construct \"Not Implemented\" response")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,9 +75,7 @@ extern crate http;
 
 use futures::future::FutureResult;
 use hyper::Body;
-use hyper::header::CONTENT_LENGTH;
 use hyper::service::Service;
-use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper::StatusCode;
 use hyper::Method;
@@ -111,7 +109,7 @@ impl Router {
     pub fn find_handler_with_defaults(&self, request: &Request<Body>) -> Handler {
         let matching_routes = self.find_matching_routes(request.uri().path());
         match matching_routes.len() {
-            x if x <= 0 => handlers::default_404_handler,
+            x if x == 0 => handlers::default_404_handler,
             _ => {
                 self.find_for_method(&matching_routes, request.method())
                     .unwrap_or(handlers::method_not_supported_handler)
@@ -127,10 +125,10 @@ impl Router {
     pub fn find_handler(&self, request: &Request<Body>) -> HttpResult<Handler> {
         let matching_routes = self.find_matching_routes(request.uri().path());
         match matching_routes.len() {
-            x if x <= 0 => Err(StatusCode::NOT_FOUND),
+            x if x == 0 => Err(StatusCode::NOT_FOUND),
             _ => {
                 self.find_for_method(&matching_routes, request.method())
-                    .map(|handler| Ok(handler))
+                    .map(Ok)
                     .unwrap_or(Err(StatusCode::METHOD_NOT_ALLOWED))
             }
         }
@@ -145,7 +143,7 @@ impl Router {
             .collect()
     }
 
-    fn find_for_method(&self, routes: &Vec<&Route>, method: &Method) -> Option<Handler> {
+    fn find_for_method(&self, routes: &[&Route], method: &Method) -> Option<Handler> {
         let method = method.clone();
         routes.iter()
             .find(|route| route.method == method)

--- a/src/path.rs
+++ b/src/path.rs
@@ -4,13 +4,13 @@ use self::regex::Regex;
 /// Represents a path in HTTP sense (starting from `/`)
 #[derive(Debug)]
 pub struct Path {
-    pub matcher: Regex
+    pub matcher: Regex,
 }
 
 impl Path {
     /// Creates a new path.
     ///
-    /// This method accepts regular expressions so you can 
+    /// This method accepts regular expressions so you can
     /// write something like this:
     ///
     /// ```no_run
@@ -18,12 +18,14 @@ impl Path {
     /// Path::new(r"/person/\d+");
     /// ```
     ///
-    /// Note that you don't have to match beggining and end of the 
+    /// Note that you don't have to match beggining and end of the
     /// path using `^` and `$` - those are inserted for you automatically.
     pub fn new(path: &str) -> Path {
         let mut regex = "^".to_string();
         regex.push_str(path);
         regex.push_str("$");
-        Path { matcher: Regex::new(&regex).unwrap() }
+        Path {
+            matcher: Regex::new(&regex).unwrap(),
+        }
     }
 }

--- a/src/route/builder.rs
+++ b/src/route/builder.rs
@@ -8,7 +8,7 @@ pub struct RouteBuilder {
 impl RouteBuilder {
     pub fn new(route: Route) -> RouteBuilder {
         RouteBuilder {
-            route: route
+            route
         }
     }
 

--- a/src/route/builder.rs
+++ b/src/route/builder.rs
@@ -1,15 +1,13 @@
-use Route;
 use Handler;
+use Route;
 
 pub struct RouteBuilder {
-    route: Route
+    route: Route,
 }
 
 impl RouteBuilder {
     pub fn new(route: Route) -> RouteBuilder {
-        RouteBuilder {
-            route
-        }
+        RouteBuilder { route }
     }
 
     /// Completes the building process by taking the handler to process the request.

--- a/src/route/mod.rs
+++ b/src/route/mod.rs
@@ -1,5 +1,5 @@
-mod route;
 mod builder;
+mod route;
 
-pub use self::route::Route;
 pub use self::builder::RouteBuilder;
+pub use self::route::Route;

--- a/src/route/route.rs
+++ b/src/route/route.rs
@@ -1,10 +1,10 @@
-use hyper::Method;
 use handlers;
+use hyper::Method;
 use std::fmt;
 
-use Path;
-use Handler;
 use super::RouteBuilder;
+use Handler;
+use Path;
 
 /// Holds route information
 pub struct Route {
@@ -29,8 +29,8 @@ pub struct Route {
     ///         .with_header(ContentType::plaintext())
     ///         .with_body(body)
     /// }
-    /// ``` 
-    pub handler: Handler
+    /// ```
+    pub handler: Handler,
 }
 
 impl Route {
@@ -74,7 +74,7 @@ impl Route {
         RouteBuilder::new(Route {
             method,
             path: Path::new(path),
-            .. Route::default()
+            ..Route::default()
         })
     }
 }
@@ -84,13 +84,17 @@ impl Default for Route {
         Route {
             method: Method::GET,
             path: Path::new("/"),
-            handler: handlers::not_implemented_handler
+            handler: handlers::not_implemented_handler,
         }
     }
 }
 
 impl fmt::Debug for Route {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Route {{method: {:?}, path: {:?}}}", self.method, self.path)
+        write!(
+            f,
+            "Route {{method: {:?}, path: {:?}}}",
+            self.method, self.path
+        )
     }
 }

--- a/src/route/route.rs
+++ b/src/route/route.rs
@@ -5,8 +5,6 @@ use std::fmt;
 use Path;
 use Handler;
 use super::RouteBuilder;
-use hyper::service::Service;
-use hyper::service::service_fn;
 
 /// Holds route information
 pub struct Route {
@@ -74,7 +72,7 @@ impl Route {
 
     pub fn from(method: Method, path: &str) -> RouteBuilder {
         RouteBuilder::new(Route {
-            method: method,
+            method,
             path: Path::new(path),
             .. Route::default()
         })

--- a/src/route/route.rs
+++ b/src/route/route.rs
@@ -5,6 +5,8 @@ use std::fmt;
 use Path;
 use Handler;
 use super::RouteBuilder;
+use hyper::service::Service;
+use hyper::service::service_fn;
 
 /// Holds route information
 pub struct Route {
@@ -35,39 +37,39 @@ pub struct Route {
 
 impl Route {
     pub fn options(path: &str) -> RouteBuilder {
-        Route::from(Method::Options, path)
+        Route::from(Method::OPTIONS, path)
     }
 
     pub fn get(path: &str) -> RouteBuilder {
-        Route::from(Method::Get, path)
+        Route::from(Method::GET, path)
     }
 
     pub fn post(path: &str) -> RouteBuilder {
-        Route::from(Method::Post, path)
+        Route::from(Method::POST, path)
     }
 
     pub fn put(path: &str) -> RouteBuilder {
-        Route::from(Method::Put, path)
+        Route::from(Method::PUT, path)
     }
 
     pub fn delete(path: &str) -> RouteBuilder {
-        Route::from(Method::Delete, path)
+        Route::from(Method::DELETE, path)
     }
 
     pub fn head(path: &str) -> RouteBuilder {
-        Route::from(Method::Head, path)
+        Route::from(Method::HEAD, path)
     }
 
     pub fn trace(path: &str) -> RouteBuilder {
-        Route::from(Method::Trace, path)
+        Route::from(Method::TRACE, path)
     }
 
     pub fn connect(path: &str) -> RouteBuilder {
-        Route::from(Method::Connect, path)
+        Route::from(Method::CONNECT, path)
     }
 
     pub fn patch(path: &str) -> RouteBuilder {
-        Route::from(Method::Patch, path)
+        Route::from(Method::PATCH, path)
     }
 
     pub fn from(method: Method, path: &str) -> RouteBuilder {
@@ -80,9 +82,9 @@ impl Route {
 }
 
 impl Default for Route {
-    fn default() -> Route {
+    fn default() -> Self {
         Route {
-            method: Method::Get,
+            method: Method::GET,
             path: Path::new("/"),
             handler: handlers::not_implemented_handler
         }

--- a/test-server/main.rs
+++ b/test-server/main.rs
@@ -1,12 +1,11 @@
 extern crate hyper;
 extern crate hyper_router;
 
-use hyper::server::Server;
-use hyper::{Body, Request, Response};
-use hyper::Method;
 use hyper::header::CONTENT_TYPE;
-use hyper_router::{Route, RouterBuilder, RouterService};
 use hyper::rt::Future;
+use hyper::server::Server;
+use hyper::{Body, Method, Request, Response};
+use hyper_router::{Route, RouterBuilder, RouterService};
 
 fn request_handler(_: Request<Body>) -> Response<Body> {
     let body = "Hello World";

--- a/test-server/main.rs
+++ b/test-server/main.rs
@@ -1,23 +1,25 @@
 extern crate hyper;
 extern crate hyper_router;
 
-use hyper::server::{Http, Request, Response};
+use hyper::server::Server;
+use hyper::{Body, Request, Response};
 use hyper::Method;
-use hyper::header::{ContentLength, ContentType};
+use hyper::header::CONTENT_TYPE;
 use hyper_router::{Route, RouterBuilder, RouterService};
+use hyper::rt::Future;
 
-fn request_handler(_: Request) -> Response {
+fn request_handler(_: Request<Body>) -> Response<Body> {
     let body = "Hello World";
-    Response::new()
-        .with_header(ContentLength(body.len() as u64))
-        .with_header(ContentType::plaintext())
-        .with_body(body)
+    Response::builder()
+        .header(CONTENT_TYPE, "text/plain")
+        .body(Body::from(body))
+        .expect("Failed to construct response")
 }
 
 fn router_service() -> Result<RouterService, std::io::Error> {
     let router = RouterBuilder::new()
         .add(Route::get("/hello").using(request_handler))
-        .add(Route::from(Method::Patch, "/asd").using(request_handler))
+        .add(Route::from(Method::PATCH, "/asd").using(request_handler))
         .build();
 
     Ok(RouterService::new(router))
@@ -25,6 +27,10 @@ fn router_service() -> Result<RouterService, std::io::Error> {
 
 fn main() {
     let addr = "0.0.0.0:8080".parse().unwrap();
-    let server = Http::new().bind(&addr, router_service).unwrap();
-    server.run().unwrap();
+
+    let server = Server::bind(&addr)
+        .serve(router_service)
+        .map_err(|e| eprintln!("server error: {}", e));
+
+    hyper::rt::run(server);
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -2,20 +2,22 @@ extern crate hyper;
 extern crate hyper_router;
 
 use hyper_router::*;
-use hyper::server::{Request, Response};
-use hyper::Method;
+use hyper::Body;
+use hyper::{Request, Response};
 use hyper::Uri;
 use std::str::FromStr;
 
 
 #[test]
 fn test_get_route() {
-    let request = Request::new(Method::Get, Uri::from_str("http://www.example.com/hello").unwrap());
+    let request = Request::get(Uri::from_str("http://www.example.com/hello").unwrap())
+        .body(Body::empty())
+        .unwrap();
 
-    fn handle_get_hello(_: Request) -> Response { unimplemented!() };
-    fn handle_get_root(_: Request) -> Response { unimplemented!() };
-    fn handle_get_foo(_: Request) -> Response { unimplemented!() };
-    fn handle_post_hello(_: Request) -> Response { unimplemented!() };
+    fn handle_get_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_get_root(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_get_foo(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
 
     let router = RouterBuilder::new()
         .add(Route::get("/hello").using(handle_get_hello))
@@ -25,18 +27,20 @@ fn test_get_route() {
         .build();
 
     let handler = router.find_handler(&request).unwrap();
-    assert!(handler as fn(_) -> _ == handle_get_hello as fn(_) -> _);
+    assert_eq!(handler as fn(_) -> _ , handle_get_hello as fn(_) -> _);
 }
 
 
 #[test]
 fn test_post_route() {
-    let request = Request::new(Method::Post, Uri::from_str("http://www.example.com/hello").unwrap());
+    let request = Request::post(Uri::from_str("http://www.example.com/hello").unwrap())
+        .body(Body::empty())
+        .unwrap();
 
-    fn handle_post_hello(_: Request) -> Response { unimplemented!() };
-    fn handle_post_root(_: Request) -> Response { unimplemented!() };
-    fn handle_post_foo(_: Request) -> Response { unimplemented!() };
-    fn handle_get_hello(_: Request) -> Response { unimplemented!() };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_post_root(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_post_foo(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_get_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
 
     let router = RouterBuilder::new()
         .add(Route::post("/hello").using(handle_post_hello))
@@ -46,16 +50,18 @@ fn test_post_route() {
         .build();
 
     let handler = router.find_handler(&request).unwrap();
-    assert!(handler as fn(_) -> _ == handle_post_hello as fn(_) -> _);
+    assert_eq!(handler as fn(_) -> _, handle_post_hello as fn(_) -> _);
 }
 
 
 #[test]
 fn test_delete_route() {
-    let request = Request::new(Method::Delete, Uri::from_str("http://www.example.com/hello").unwrap());
+    let request = Request::delete(Uri::from_str("http://www.example.com/hello").unwrap())
+        .body(Body::empty())
+        .unwrap();
 
-    fn handle_delete_hello(_: Request) -> Response { unimplemented!() };
-    fn handle_post_hello(_: Request) -> Response { unimplemented!() };
+    fn handle_delete_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
 
     let router = RouterBuilder::new()
         .add(Route::delete("/hello").using(handle_delete_hello))
@@ -63,16 +69,18 @@ fn test_delete_route() {
         .build();
 
     let handler = router.find_handler(&request).unwrap();
-    assert!(handler as fn(_) -> _ == handle_delete_hello as fn(_) -> _);
+    assert_eq!(handler as fn(_) -> _, handle_delete_hello as fn(_) -> _);
 }
 
 
 #[test]
 fn test_options_route() {
-    let request = Request::new(Method::Options, Uri::from_str("http://www.example.com/hello").unwrap());
+    let request = Request::options(Uri::from_str("http://www.example.com/hello").unwrap())
+        .body(Body::empty())
+        .unwrap();
 
-    fn handle_options_hello(_: Request) -> Response { unimplemented!() };
-    fn handle_post_hello(_: Request) -> Response { unimplemented!() };
+    fn handle_options_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
 
     let router = RouterBuilder::new()
         .add(Route::options("/hello").using(handle_options_hello))
@@ -80,16 +88,18 @@ fn test_options_route() {
         .build();
 
     let handler = router.find_handler(&request).unwrap();
-    assert!(handler as fn(_) -> _ == handle_options_hello as fn(_) -> _);
+    assert_eq!(handler as fn(_) -> _, handle_options_hello as fn(_) -> _);
 }
 
 
 #[test]
 fn test_put_route() {
-    let request = Request::new(Method::Put, Uri::from_str("http://www.example.com/hello").unwrap());
+    let request = Request::put(Uri::from_str("http://www.example.com/hello").unwrap())
+        .body(Body::empty())
+        .unwrap();
 
-    fn handle_put_hello(_: Request) -> Response { unimplemented!() };
-    fn handle_post_hello(_: Request) -> Response { unimplemented!() };
+    fn handle_put_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
 
     let router = RouterBuilder::new()
         .add(Route::put("/hello").using(handle_put_hello))
@@ -97,16 +107,18 @@ fn test_put_route() {
         .build();
 
     let handler = router.find_handler(&request).unwrap();
-    assert!(handler as fn(_) -> _ == handle_put_hello as fn(_) -> _);
+    assert_eq!(handler as fn(_) -> _, handle_put_hello as fn(_) -> _);
 }
 
 
 #[test]
 fn test_head_route() {
-    let request = Request::new(Method::Head, Uri::from_str("http://www.example.com/hello").unwrap());
+    let request = Request::head(Uri::from_str("http://www.example.com/hello").unwrap())
+        .body(Body::empty())
+        .unwrap();
 
-    fn handle_head_hello(_: Request) -> Response { unimplemented!() };
-    fn handle_post_hello(_: Request) -> Response { unimplemented!() };
+    fn handle_head_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
 
     let router = RouterBuilder::new()
         .add(Route::head("/hello").using(handle_head_hello))
@@ -114,16 +126,18 @@ fn test_head_route() {
         .build();
 
     let handler = router.find_handler(&request).unwrap();
-    assert!(handler as fn(_) -> _ == handle_head_hello as fn(_) -> _);
+    assert_eq!(handler as fn(_) -> _, handle_head_hello as fn(_) -> _);
 }
 
 
 #[test]
 fn test_trace_route() {
-    let request = Request::new(Method::Trace, Uri::from_str("http://www.example.com/hello").unwrap());
+    let request = Request::trace(Uri::from_str("http://www.example.com/hello").unwrap())
+        .body(Body::empty())
+        .unwrap();
 
-    fn handle_trace_hello(_: Request) -> Response { unimplemented!() };
-    fn handle_post_hello(_: Request) -> Response { unimplemented!() };
+    fn handle_trace_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
 
     let router = RouterBuilder::new()
         .add(Route::trace("/hello").using(handle_trace_hello))
@@ -131,16 +145,18 @@ fn test_trace_route() {
         .build();
 
     let handler = router.find_handler(&request).unwrap();
-    assert!(handler as fn(_) -> _ == handle_trace_hello as fn(_) -> _);
+    assert_eq!(handler as fn(_) -> _, handle_trace_hello as fn(_) -> _);
 }
 
 
 #[test]
 fn test_patch_route() {
-    let request = Request::new(Method::Patch, Uri::from_str("http://www.example.com/hello").unwrap());
+    let request = Request::patch(Uri::from_str("http://www.example.com/hello").unwrap())
+        .body(Body::empty())
+        .unwrap();
 
-    fn handle_patch_hello(_: Request) -> Response { unimplemented!() };
-    fn handle_post_hello(_: Request) -> Response { unimplemented!() };
+    fn handle_patch_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
 
     let router = RouterBuilder::new()
         .add(Route::patch("/hello").using(handle_patch_hello))
@@ -148,16 +164,18 @@ fn test_patch_route() {
         .build();
 
     let handler = router.find_handler(&request).unwrap();
-    assert!(handler as fn(_) -> _ == handle_patch_hello as fn(_) -> _);
+    assert_eq!(handler as fn(_) -> _, handle_patch_hello as fn(_) -> _);
 }
 
 
 #[test]
 fn test_no_route() {
-    let request = Request::new(Method::Get, Uri::from_str("http://www.example.com/notfound").unwrap());
+    let request = Request::get(Uri::from_str("http://www.example.com/notfound").unwrap())
+        .body(Body::empty())
+        .unwrap();
 
-    fn handle_get_foo(_: Request) -> Response { unimplemented!() };
-    fn handle_get_bar(_: Request) -> Response { unimplemented!() };
+    fn handle_get_foo(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_get_bar(_: Request<Body>) -> Response<Body> { unimplemented!() };
 
     let router = RouterBuilder::new()
         .add(Route::patch("/foo").using(handle_get_foo))
@@ -168,17 +186,19 @@ fn test_no_route() {
 
     match handler {
         Ok(_) => panic!("Expected an error, but got a handler instead"),
-        Err(e) => assert_eq!(e, hyper::StatusCode::NotFound)
+        Err(e) => assert_eq!(e, hyper::StatusCode::NOT_FOUND)
     }
 }
 
 
 #[test]
 fn test_regex_path() {
-    let request = Request::new(Method::Get, Uri::from_str("http://www.example.com/foo/bar").unwrap());
+    let request = Request::get(Uri::from_str("http://www.example.com/foo/bar").unwrap())
+        .body(Body::empty())
+        .unwrap();
 
-    fn handle_regex_foo(_: Request) -> Response { unimplemented!() };
-    fn handle_regex_bar(_: Request) -> Response { unimplemented!() };
+    fn handle_regex_foo(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_regex_bar(_: Request<Body>) -> Response<Body> { unimplemented!() };
 
     let router = RouterBuilder::new()
         .add(Route::get(r"/foo/.*?").using(handle_regex_foo))
@@ -186,5 +206,5 @@ fn test_regex_path() {
         .build();
 
     let handler = router.find_handler(&request).unwrap();
-    assert!(handler as fn(_) -> _ == handle_regex_foo as fn(_) -> _);
+    assert_eq!(handler as fn(_) -> _, handle_regex_foo as fn(_) -> _);
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,12 +1,10 @@
 extern crate hyper;
 extern crate hyper_router;
 
-use hyper_router::*;
-use hyper::Body;
-use hyper::{Request, Response};
 use hyper::Uri;
+use hyper::{Body, Request, Response};
+use hyper_router::*;
 use std::str::FromStr;
-
 
 #[test]
 fn test_get_route() {
@@ -14,10 +12,18 @@ fn test_get_route() {
         .body(Body::empty())
         .unwrap();
 
-    fn handle_get_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_get_root(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_get_foo(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_get_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_get_root(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_get_foo(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
 
     let router = RouterBuilder::new()
         .add(Route::get("/hello").using(handle_get_hello))
@@ -27,9 +33,8 @@ fn test_get_route() {
         .build();
 
     let handler = router.find_handler(&request).unwrap();
-    assert_eq!(handler as fn(_) -> _ , handle_get_hello as fn(_) -> _);
+    assert_eq!(handler as fn(_) -> _, handle_get_hello as fn(_) -> _);
 }
-
 
 #[test]
 fn test_post_route() {
@@ -37,10 +42,18 @@ fn test_post_route() {
         .body(Body::empty())
         .unwrap();
 
-    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_post_root(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_post_foo(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_get_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_post_root(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_post_foo(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_get_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
 
     let router = RouterBuilder::new()
         .add(Route::post("/hello").using(handle_post_hello))
@@ -53,15 +66,18 @@ fn test_post_route() {
     assert_eq!(handler as fn(_) -> _, handle_post_hello as fn(_) -> _);
 }
 
-
 #[test]
 fn test_delete_route() {
     let request = Request::delete(Uri::from_str("http://www.example.com/hello").unwrap())
         .body(Body::empty())
         .unwrap();
 
-    fn handle_delete_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_delete_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
 
     let router = RouterBuilder::new()
         .add(Route::delete("/hello").using(handle_delete_hello))
@@ -72,15 +88,18 @@ fn test_delete_route() {
     assert_eq!(handler as fn(_) -> _, handle_delete_hello as fn(_) -> _);
 }
 
-
 #[test]
 fn test_options_route() {
     let request = Request::options(Uri::from_str("http://www.example.com/hello").unwrap())
         .body(Body::empty())
         .unwrap();
 
-    fn handle_options_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_options_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
 
     let router = RouterBuilder::new()
         .add(Route::options("/hello").using(handle_options_hello))
@@ -91,15 +110,18 @@ fn test_options_route() {
     assert_eq!(handler as fn(_) -> _, handle_options_hello as fn(_) -> _);
 }
 
-
 #[test]
 fn test_put_route() {
     let request = Request::put(Uri::from_str("http://www.example.com/hello").unwrap())
         .body(Body::empty())
         .unwrap();
 
-    fn handle_put_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_put_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
 
     let router = RouterBuilder::new()
         .add(Route::put("/hello").using(handle_put_hello))
@@ -110,15 +132,18 @@ fn test_put_route() {
     assert_eq!(handler as fn(_) -> _, handle_put_hello as fn(_) -> _);
 }
 
-
 #[test]
 fn test_head_route() {
     let request = Request::head(Uri::from_str("http://www.example.com/hello").unwrap())
         .body(Body::empty())
         .unwrap();
 
-    fn handle_head_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_head_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
 
     let router = RouterBuilder::new()
         .add(Route::head("/hello").using(handle_head_hello))
@@ -129,15 +154,18 @@ fn test_head_route() {
     assert_eq!(handler as fn(_) -> _, handle_head_hello as fn(_) -> _);
 }
 
-
 #[test]
 fn test_trace_route() {
     let request = Request::trace(Uri::from_str("http://www.example.com/hello").unwrap())
         .body(Body::empty())
         .unwrap();
 
-    fn handle_trace_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_trace_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
 
     let router = RouterBuilder::new()
         .add(Route::trace("/hello").using(handle_trace_hello))
@@ -148,15 +176,18 @@ fn test_trace_route() {
     assert_eq!(handler as fn(_) -> _, handle_trace_hello as fn(_) -> _);
 }
 
-
 #[test]
 fn test_patch_route() {
     let request = Request::patch(Uri::from_str("http://www.example.com/hello").unwrap())
         .body(Body::empty())
         .unwrap();
 
-    fn handle_patch_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_post_hello(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_patch_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_post_hello(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
 
     let router = RouterBuilder::new()
         .add(Route::patch("/hello").using(handle_patch_hello))
@@ -167,15 +198,18 @@ fn test_patch_route() {
     assert_eq!(handler as fn(_) -> _, handle_patch_hello as fn(_) -> _);
 }
 
-
 #[test]
 fn test_no_route() {
     let request = Request::get(Uri::from_str("http://www.example.com/notfound").unwrap())
         .body(Body::empty())
         .unwrap();
 
-    fn handle_get_foo(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_get_bar(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_get_foo(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_get_bar(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
 
     let router = RouterBuilder::new()
         .add(Route::patch("/foo").using(handle_get_foo))
@@ -186,10 +220,9 @@ fn test_no_route() {
 
     match handler {
         Ok(_) => panic!("Expected an error, but got a handler instead"),
-        Err(e) => assert_eq!(e, hyper::StatusCode::NOT_FOUND)
+        Err(e) => assert_eq!(e, hyper::StatusCode::NOT_FOUND),
     }
 }
-
 
 #[test]
 fn test_regex_path() {
@@ -197,8 +230,12 @@ fn test_regex_path() {
         .body(Body::empty())
         .unwrap();
 
-    fn handle_regex_foo(_: Request<Body>) -> Response<Body> { unimplemented!() };
-    fn handle_regex_bar(_: Request<Body>) -> Response<Body> { unimplemented!() };
+    fn handle_regex_foo(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
+    fn handle_regex_bar(_: Request<Body>) -> Response<Body> {
+        unimplemented!()
+    };
 
     let router = RouterBuilder::new()
         .add(Route::get(r"/foo/.*?").using(handle_regex_foo))


### PR DESCRIPTION
Hello, @marad!

I've ported hyper-router to `Hyper 0.12`, please look through the changes and say what do you think about these breaking changes that are necessary for the next version of hyper and if they can land into `hyper-router 0.5`

I've decided to support only the `Body` type in generic body position for `Request` and `Response` as there seems to be no way to generalize `Router` middleware abstraction over an open set of  `Request/Response` generic arguments.

